### PR TITLE
feat: add amplitude damping Kraus demo

### DIFF
--- a/qcqi_pure_math_playground.py
+++ b/qcqi_pure_math_playground.py
@@ -212,7 +212,7 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float:
 # ======================================
 
 def choi_from_kraus(kraus_ops):
-    """Choi J(E) = sum_i (K_i \otimes I) |Phi><Phi| (K_i^\dagger \otimes I), |Phi>=sum_j |jj>/sqrt(d)."""
+    r"""Choi J(E) = sum_i (K_i \otimes I) |Phi><Phi| (K_i^\dagger \otimes I), |Phi>=sum_j |jj>/\sqrt(d)."""
     d = kraus_ops[0].shape[0]
     phi = np.zeros((d * d, 1), dtype=complex)
     for j in range(d):
@@ -245,6 +245,20 @@ def dephasing_kraus(p: float):
 
 def dephase_rho(rho: np.ndarray, p: float) -> np.ndarray:
     Ks = dephasing_kraus(p)
+    out = np.zeros_like(rho, dtype=complex)
+    for K in Ks:
+        out += K @ rho @ np.conjugate(K.T)
+    return out
+
+
+def amplitude_damping_kraus(gamma: float):
+    K0 = np.array([[1, 0], [0, np.sqrt(1 - gamma)]], dtype=complex)
+    K1 = np.array([[0, np.sqrt(gamma)], [0, 0]], dtype=complex)
+    return [K0, K1]
+
+
+def amplitude_damp_rho(rho: np.ndarray, gamma: float) -> np.ndarray:
+    Ks = amplitude_damping_kraus(gamma)
     out = np.zeros_like(rho, dtype=complex)
     for K in Ks:
         out += K @ rho @ np.conjugate(K.T)
@@ -362,3 +376,12 @@ if __name__ == "__main__":
         out = partial_trace(rho232, keep=ks, dims=dims_232)
         ok_shape = (out.shape == expected)
         print(f"[{'PASS' if ok_shape else 'FAIL'}] shape keep={ks}: got {out.shape}, expected {expected}")
+
+    # 8) Amplitude damping-demo op |1>
+    ok, tp, cp, evals = is_cptp(amplitude_damping_kraus(0.25))
+    print("Amplitude damping CPTP:", ok, " (TP:", tp, ", CP:", cp, ") eigenwaarden Choi:", evals)
+    rho1 = to_density(ket1)
+    for g in (0.0, 0.3, 0.7, 1.0):
+        rout = amplitude_damp_rho(rho1, g)
+        vec = bloch_vector_from_rho(rout)
+        print(f"gamma={g}  Bloch: {vec}")


### PR DESCRIPTION
## Summary
- add amplitude damping Kraus operators and channel helper
- demo channel CPTP check and Bloch evolution

## Testing
- `python quant_math_lab.py`
- `python qcqi_pure_math_playground.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9878a4f448331be88c63d13421b1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an amplitude damping quantum channel, including application to density matrices and example usage across multiple damping strengths.
- Documentation
  - Improved Choi-from-Kraus documentation formatting for clearer interpretation.
- Tests
  - Added a playground demo that verifies the channel is CPTP, prints Choi eigenvalues, and shows resulting Bloch vectors for sample parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->